### PR TITLE
Fixed reference to UnityEditor that can break builds.

### DIFF
--- a/ZEDCamera/Assets/ZED/SDK/Helpers/Scripts/ZEDManager.cs
+++ b/ZEDCamera/Assets/ZED/SDK/Helpers/Scripts/ZEDManager.cs
@@ -752,7 +752,9 @@ public class ZEDManager : MonoBehaviour
         {
             LayerMask layerNumberBinary = (1 << righteyelayerfinal); //Convert layer index into binary number. 
             layerNumberBinary |= (1 << lefteyelayerfinal);
+#if UNITY_EDITOR
             UnityEditor.Tools.visibleLayers |= (layerNumberBinary);
+#endif
         }
     }
 


### PR DESCRIPTION
Forgot you can't reference UnityEditor in a script that gets built. Added #if UNITY_EDITOR to fix that. 