### PR TITLE
Replace deprecated UnityEngine.VR and UnityEngine.VR.VRDevice with Un…

### DIFF
--- a/ZEDCamera/Assets/ZED/Examples/Mixed Reality Calibration/Scripts/ForceTrackingSpaceType.cs
+++ b/ZEDCamera/Assets/ZED/Examples/Mixed Reality Calibration/Scripts/ForceTrackingSpaceType.cs
@@ -8,12 +8,12 @@ using UnityEngine;
 /// </summary>
 public class ForceTrackingSpaceType : MonoBehaviour
 {
-    public UnityEngine.VR.TrackingSpaceType trackingType = UnityEngine.VR.TrackingSpaceType.RoomScale;
+    public UnityEngine.XR.TrackingSpaceType trackingType = UnityEngine.XR.TrackingSpaceType.RoomScale;
 
     // Use this for initialization
     void Start ()
     {
-        UnityEngine.VR.VRDevice.SetTrackingSpaceType(trackingType);
+        UnityEngine.XR.XRDevice.SetTrackingSpaceType(trackingType);
     }
 	
 }


### PR DESCRIPTION
UnityEngine.VR is deprecated and throws an error in Unity 2019.2.16f1.