### PR TITLE
Fix ChooseTrackedObjectMenu.cs

### DIFF
--- a/ZEDCamera/Assets/ZED/Examples/Mixed Reality Calibration/Scripts/ChooseTrackedObjectMenu.cs
+++ b/ZEDCamera/Assets/ZED/Examples/Mixed Reality Calibration/Scripts/ChooseTrackedObjectMenu.cs
@@ -267,8 +267,14 @@ public class ChooseTrackedObjectMenu : MonoBehaviour
         }*/
 
         //Make a left controller button. 
-        allButtons.Add(CreateTrackedObjectPrefab(TOUCH_INDEX_LEFT));
-        allButtons.Add(CreateTrackedObjectPrefab(TOUCH_INDEX_RIGHT));
+        ChooseTrackedObjectButton leftButton;
+        CreateTrackedObjectPrefab(TOUCH_INDEX_LEFT, out leftButton);
+        allButtons.Add(leftButton);
+
+        //Make a right controller button. 
+        ChooseTrackedObjectButton rightButton;
+        CreateTrackedObjectPrefab(TOUCH_INDEX_RIGHT, out rightButton);
+        allButtons.Add(rightButton);
 #endif
         ArrangeIntoGrid(allButtons, objectWidth, objectHeight, maxColumns);
     }


### PR DESCRIPTION
Perhaps a different implementation is wanted, but it seems that `CreateTrackedObjectPrefab` returns a `GameObject`, so it can't be added to `allButtons`. Therefore this is currently the best solution, unless the return type is changed of `CreateTrackedObjectPrefab`. I'm assuming this has already been done, but it wasn't merged.