### PR TITLE
include built-in dependencies in the list

### DIFF
--- a/ZEDCamera/Assets/package.json
+++ b/ZEDCamera/Assets/package.json
@@ -9,7 +9,10 @@
   "changelogUrl": "https://github.com/stereolabs/zed-unity/releases",
   "licensesUrl": "https://github.com/stereolabs/zed-unity?tab=MIT-1-ov-file#readme",
   "dependencies": {
-    "com.unity.xr.management": "4.4.0"
+    "com.unity.xr.management": "4.4.0",
+    "com.unity.ugui": "2.0.0",
+    "com.unity.modules.animation": "1.0.0",
+    "com.unity.modules.imageconversion": "1.0.0"
   },
   "keywords": [
     "ZED SDK",
@@ -44,7 +47,7 @@
     },
     {
       "displayName": "Green Screen",
-      "description": "Aim your ZED at a greenscreen and hit Play to see your subject standing in a small town in the desert. You’ll see that the nearby crates still have all the proper occlusion, but the greenscreen background is replaced with the virtual background.",
+      "description": "Aim your ZED at a greenscreen and hit Play to see your subject standing in a small town in the desert. You\u2019ll see that the nearby crates still have all the proper occlusion, but the greenscreen background is replaced with the virtual background.",
       "path": "Samples~/Green Screen"
     },
     {
@@ -79,12 +82,12 @@
     },
     {
       "displayName": "Plane Detection",
-      "description": "Run the scene and hold down spacebar to see if you’re looking at a valid surface where a bunny could stand. Release the spacebar and a bunny will fall from the sky and land on that surface with proper physics. In VR, throw a plushie as far as possible, the distance is measured where it lands using the Plane Detection. Shows how plane detection can fit into a proper VR game.",
+      "description": "Run the scene and hold down spacebar to see if you\u2019re looking at a valid surface where a bunny could stand. Release the spacebar and a bunny will fall from the sky and land on that surface with proper physics. In VR, throw a plushie as far as possible, the distance is measured where it lands using the Plane Detection. Shows how plane detection can fit into a proper VR game.",
       "path": "Samples~/Plane Detection"
     },
     {
       "displayName": "Planetarium",
-      "description": "A beautiful display of the ZED plugin’s basic mixed reality features, viewable with or without a headset. Watch as the planets are properly occluded by the real world.",
+      "description": "A beautiful display of the ZED plugin\u2019s basic mixed reality features, viewable with or without a headset. Watch as the planets are properly occluded by the real world.",
       "path": "Samples~/Planetarium"
     },
     {


### PR DESCRIPTION
These dependencies are normally included in a project, but if someone disables them in their project, they will face compile errors since zed package expects them to be there.
By adding them to the list of dependencies here, Unity keeps them enabled as dependencies even if they're set to be disabled by the user.