### PR TITLE
Bug: Added gate for non ZED Cameras with Frame children.

### DIFF
--- a/ZEDCamera/Assets/SDK/Helpers/Scripts/Utilities/UpgradePluginToSRP.cs
+++ b/ZEDCamera/Assets/SDK/Helpers/Scripts/Utilities/UpgradePluginToSRP.cs
@@ -18,7 +18,14 @@ public static class UpgradePluginToSRP
 
                 foreach (var cam in cameras)
                 {
-                    cam.transform.Find("Frame").GetComponent<MeshRenderer>().sharedMaterial = Mat_Zed_Forward_Lighting;
+                    var frame = cam.transform.Find("Frame");
+                    if (frame )
+                    {
+                        if (frame.TryGetComponent<MeshRenderer>(out MeshRenderer meshRenderer))
+                        {
+                            meshRenderer.sharedMaterial = Mat_Zed_Forward_Lighting;
+                        }
+                    }
                 }
 
                 if (cameras.Length > 0)
@@ -38,7 +45,14 @@ public static class UpgradePluginToSRP
 
                 foreach (var cam in cameras)
                 {
-                    cam.transform.Find("Frame").GetComponent<MeshRenderer>().sharedMaterial = Mat_Zed_Forward_Lighting;
+                    var frame = cam.transform.Find("Frame");
+                    if (frame )
+                    {
+                        if (frame.TryGetComponent<MeshRenderer>(out MeshRenderer meshRenderer))
+                        {
+                            meshRenderer.sharedMaterial = Mat_Zed_Forward_Lighting;
+                        }
+                    }
                 }
 
                 if (cameras.Length > 0)


### PR DESCRIPTION
Just incase devs place other cameras as children of a  ``ZEDManager``. The previous code would cause the rest of the`` ZedManager`` and rendering system to not work.