### PR TITLE
Remove unused using directive to avoid compilation errors when the Unity Version Control package is not imported

### DIFF
--- a/ZEDCamera/Assets/SDK/Helpers/Scripts/SpatialMapping/ZEDSpatialMapping.cs
+++ b/ZEDCamera/Assets/SDK/Helpers/Scripts/SpatialMapping/ZEDSpatialMapping.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Runtime.InteropServices;
 using System.Threading;
 using UnityEngine;
-using static log4net.Appender.ColoredConsoleAppender;
 
 /// <summary>
 /// Processes the mesh taken from the ZED's Spatial Mapping feature so it can be used within Unity.


### PR DESCRIPTION
**Proposal**

There is an unused using directive in the ZEDSpatialMapping.cs file that leads to compile errors when the Unity Version Control package is not installed in the project.

The using directive has been removed to avoid the error.